### PR TITLE
Upgrade Lambda function to Node.js 22.x runtime

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import * as aws from "@pulumi/aws";
 import { Runtime } from "@pulumi/aws/lambda";
 
 const eventHandler = new aws.lambda.CallbackFunction("handler", {
-    runtime: Runtime.NodeJS18dX,
+    runtime: Runtime.NodeJS22dX,
     callback: async () => {
         return {
             statusCode: 200,


### PR DESCRIPTION
# Upgrade AWS Lambda Runtime to Node.js 22.x

## Overview
This PR upgrades the AWS Lambda function runtime from Node.js 18.x to Node.js 22.x, which is the latest supported version on AWS Lambda.

## Changes Made
- **Updated runtime**: Changed `Runtime.NodeJS18dX` to `Runtime.NodeJS22dX` for the `handler` Lambda function

## Function Details
- **Function Name**: `handler`
- **Project**: `pose-sample-app`
- **Stack**: `pose-sample-pulumi-app`
- **Runtime Change**: Node.js 18.x → Node.js 22.x

## Benefits of Upgrading
- **Performance Improvements**: Node.js 22.x includes performance optimizations and newer V8 engine
- **Security Updates**: Latest security patches and vulnerability fixes
- **Language Features**: Access to newer JavaScript/TypeScript language features
- **Long-term Support**: Node.js 18.x will reach end-of-life in April 2025

## Testing Recommendations
- Verify the Lambda function continues to work correctly after deployment
- Test API Gateway endpoints to ensure compatibility
- Monitor CloudWatch logs for any runtime-related issues

## Deployment Impact
- **Risk Level**: Low - Node.js 22.x maintains backward compatibility
- **Downtime**: None expected - Lambda functions are updated atomically
- **Rollback**: Can be easily reverted if issues arise