### PR TITLE
Downgrade AWS provider to v6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "pose-sample-app",
     "dependencies": {
-        "@pulumi/aws": "^7.0.0",
-        "@pulumi/aws-apigateway": "^3.0.0"
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-apigateway": "^2.0.0"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",


### PR DESCRIPTION
## Summary

This PR downgrades the AWS provider from v7.4.0 to v6.x as requested.

## Changes Made

- Updated `@pulumi/aws` from `^7.0.0` to `^6.0.0` in package.json
- Updated `@pulumi/aws-apigateway` from `^3.0.0` to `^2.0.0` for compatibility

## Testing

✅ Pulumi preview completed successfully with no breaking changes
- All resources preview correctly with minimal tag updates
- No code changes required - the Lambda runtime `Runtime.NodeJS18dX` is compatible with v6
- Lambda permission replacement is expected due to provider version change

## Impact

- Infrastructure will use AWS provider v6.x instead of v7.x
- No breaking changes to existing resources
- All functionality preserved